### PR TITLE
Refactor powerup spawner

### DIFF
--- a/Assets/Scripts/PowerUps/PowerUpSpawner.cs
+++ b/Assets/Scripts/PowerUps/PowerUpSpawner.cs
@@ -10,14 +10,13 @@ namespace PowerUps
 
         public GameObject healthPrefab;
         public GameObject hologramPickupPrefab;
-        public GameObject hologramShipPrefab;
         public GameObject shieldPrefab;
         public GameObject gatePrefab;
         public GameObject superModePrefab;
-        public GameObject explosionPrefab;
         public float spawnTimeSpanStart = 2.0f;
         public float spawnTimeSpanEnd = 5.0f;
         private DateTime nextSpawnTime = DateTime.Now;
+        private Camera camera;
 
         // Add Group spawning support
         private Dictionary<PowerUpType, double> spawnChances = new Dictionary<PowerUpType, double>()
@@ -32,6 +31,7 @@ namespace PowerUps
         private void Start()
         {
             nextSpawnTime = DateTime.Now + TimeSpan.FromSeconds(Random.Range(spawnTimeSpanStart, spawnTimeSpanEnd));
+            camera = Camera.main;
         }
 
         private void Update()
@@ -42,21 +42,18 @@ namespace PowerUps
                 nextSpawnTime =
                     DateTime.Now + TimeSpan.FromSeconds(Random.Range(spawnTimeSpanStart, spawnTimeSpanEnd));
                 var toGenerate = GenerateNextPowerUpTypes();
-                GameObject powerUp = null;
                 foreach (PowerUpType powerUpType in toGenerate)
                 {
                     switch (powerUpType)
                     {
                         case PowerUpType.Gate:
-                            powerUp = Instantiate(gatePrefab, GeneratePowerUpStartingPosition(), Quaternion.Euler(0.0f, 0.0f, Random.Range(0.0f, 360.0f)));
-                            powerUp.GetComponent<GateController>().explosionPrefab = explosionPrefab;
+                            Instantiate(gatePrefab, GeneratePowerUpStartingPosition(), Quaternion.Euler(0.0f, 0.0f, Random.Range(0.0f, 360.0f)));
                             break;
                         case PowerUpType.Health:
                             Instantiate(healthPrefab, GeneratePowerUpStartingPosition(), Quaternion.Euler(0.0f, 0.0f, Random.Range(0.0f, 360.0f)));
                             break;
                         case PowerUpType.Hologram:
-                            powerUp = Instantiate(hologramPickupPrefab, GeneratePowerUpStartingPosition(), Quaternion.Euler(0.0f, 0.0f, Random.Range(0.0f, 360.0f)));
-                            powerUp.GetComponent<HologramPowerup>().hologramPrefab = hologramShipPrefab;
+                            Instantiate(hologramPickupPrefab, GeneratePowerUpStartingPosition(), Quaternion.Euler(0.0f, 0.0f, Random.Range(0.0f, 360.0f)));
                             break;
                         case PowerUpType.Shield:
                             Instantiate(shieldPrefab, GeneratePowerUpStartingPosition(), Quaternion.Euler(0.0f, 0.0f, Random.Range(0.0f, 360.0f)));
@@ -80,7 +77,6 @@ namespace PowerUps
         
         private Vector2 GeneratePowerUpStartingPosition()
         {
-            var camera = Camera.main;
             Vector2 startPosition = new Vector2(Random.Range(-55, 55), Random.Range(-25, 25));
             while (CameraContainsPoint(camera, startPosition))
             {

--- a/Assets/Scripts/PowerUps/PowerUpSpawner.cs
+++ b/Assets/Scripts/PowerUps/PowerUpSpawner.cs
@@ -16,7 +16,7 @@ namespace PowerUps
         public float spawnTimeSpanStart = 2.0f;
         public float spawnTimeSpanEnd = 5.0f;
         private DateTime nextSpawnTime = DateTime.Now;
-        private Camera camera;
+        private Camera cam;
 
         // Add Group spawning support
         private Dictionary<PowerUpType, double> spawnChances = new Dictionary<PowerUpType, double>()
@@ -31,7 +31,7 @@ namespace PowerUps
         private void Start()
         {
             nextSpawnTime = DateTime.Now + TimeSpan.FromSeconds(Random.Range(spawnTimeSpanStart, spawnTimeSpanEnd));
-            camera = Camera.main;
+            cam = Camera.main;
         }
 
         private void Update()
@@ -78,7 +78,7 @@ namespace PowerUps
         private Vector2 GeneratePowerUpStartingPosition()
         {
             Vector2 startPosition = new Vector2(Random.Range(-55, 55), Random.Range(-25, 25));
-            while (CameraContainsPoint(camera, startPosition))
+            while (CameraContainsPoint(cam, startPosition))
             {
                 startPosition = new Vector2(Random.Range(-55, 55), Random.Range(-25, 25));
             }


### PR DESCRIPTION
I just looked at the code of powerup spawner and found two places where things could be improved:
- We only use one camera, so no need to get the reference each time a point is checked (The property has a small cpu overhead). It's easier to store the reference at the start of the game.
- There is no need to set the explosion and hologram prefabs of the powerup prefabs. Prefabs can store reference to other prefabs, its only necesary to set them, if the referenced GameObject is already in the secen. ie if you want to set the player GameObject.